### PR TITLE
Use minute instead of month in logger timestamp

### DIFF
--- a/src/Winium.Desktop.Driver/Logger.cs
+++ b/src/Winium.Desktop.Driver/Logger.cs
@@ -13,7 +13,7 @@
     {
         #region Constants
 
-        private const string LayoutFormat = "${date:format=HH\\:MM\\:ss} [${level:uppercase=true}] ${message}";
+        private const string LayoutFormat = "${date:format=HH\\:mm\\:ss} [${level:uppercase=true}] ${message}";
 
         #endregion
 


### PR DESCRIPTION
Backport fix by @magnarn from Winium.StoreApps