### PR TITLE
Touch methods

### DIFF
--- a/src/Winium.Desktop.Driver/CommandExecutors/GetElementLocationExecutor.cs
+++ b/src/Winium.Desktop.Driver/CommandExecutors/GetElementLocationExecutor.cs
@@ -1,0 +1,33 @@
+﻿namespace Winium.Desktop.Driver.CommandExecutors
+{
+    #region using
+
+    using System.Collections.Generic;
+
+    using Winium.StoreApps.Common;
+
+    #endregion
+
+    internal class GetElementLocationExecutor : CommandExecutorBase
+    {
+        #region Methods
+
+        protected override string DoImpl()
+        {
+            var registeredKey = this.ExecutedCommand.Parameters["ID"].ToString();
+
+            var element = this.Automator.ElementsRegistry.GetRegisteredElement(registeredKey);
+
+            var boundingRect = element.Properties.BoundingRectangle;
+
+            var response = new Dictionary<string, object>
+                               {
+                                   { "x", boundingRect.X }, 
+                                   { "y", boundingRect.Y }
+                               };
+            return this.JsonResponse(ResponseStatus.Success, response);
+        }
+
+        #endregion
+    }
+}

--- a/src/Winium.Desktop.Driver/CommandExecutors/TouchDoubleTapExecutor.cs
+++ b/src/Winium.Desktop.Driver/CommandExecutors/TouchDoubleTapExecutor.cs
@@ -1,0 +1,32 @@
+namespace Winium.Desktop.Driver.CommandExecutors
+{
+    #region using
+
+    using Winium.Cruciatus.Core;
+    using Winium.StoreApps.Common;
+
+    #endregion
+
+    internal class TouchDoubleTapExecutor : CommandExecutorBase
+    {
+        #region Methods
+
+        protected override string DoImpl()
+        {
+            if (!this.ExecutedCommand.Parameters.ContainsKey("element"))
+            {
+                // TODO: in the future '400 : invalid argument' will be used
+                return this.JsonResponse(ResponseStatus.UnknownError, "WRONG PARAMETERS");
+            }
+
+            var registeredKey = this.ExecutedCommand.Parameters["element"].ToString();
+            var element = this.Automator.ElementsRegistry.GetRegisteredElement(registeredKey);
+
+            return TouchSimulator.DoubleTap(element)
+                ? this.JsonResponse()
+                : this.JsonResponse(ResponseStatus.UnknownError, "Touch input failed");
+        }
+
+        #endregion
+    }
+}

--- a/src/Winium.Desktop.Driver/CommandExecutors/TouchFlickExecutor.cs
+++ b/src/Winium.Desktop.Driver/CommandExecutors/TouchFlickExecutor.cs
@@ -8,6 +8,7 @@ namespace Winium.Desktop.Driver.CommandExecutors
 
     using Winium.Cruciatus;
     using Winium.Cruciatus.Core;
+    using Winium.Desktop.Driver.Extensions;
     using Winium.StoreApps.Common;
 
     #endregion
@@ -35,8 +36,8 @@ namespace Winium.Desktop.Driver.CommandExecutors
                 return this.JsonResponse(ResponseStatus.UnknownError, "WRONG PARAMETERS");
             }
 
-            var xSpeed = Convert.ToInt32(this.ExecutedCommand.Parameters["xspeed"]);
-            var ySpeed = Convert.ToInt32(this.ExecutedCommand.Parameters["yspeed"]);
+            var xSpeed = this.ExecutedCommand.GetParameterAsInt("xspeed");
+            var ySpeed = this.ExecutedCommand.GetParameterAsInt("yspeed");
 
             return TouchSimulator.Flick(xSpeed, ySpeed)
                 ? this.JsonResponse()
@@ -58,10 +59,10 @@ namespace Winium.Desktop.Driver.CommandExecutors
             var registeredKey = this.ExecutedCommand.Parameters["element"].ToString();
             var element = this.Automator.ElementsRegistry.GetRegisteredElement(registeredKey);
 
-            var xOffset = Convert.ToInt32(this.ExecutedCommand.Parameters["xoffset"]);
-            var yOffset = Convert.ToInt32(this.ExecutedCommand.Parameters["yoffset"]);
+            var xOffset = this.ExecutedCommand.GetParameterAsInt("xoffset");
+            var yOffset = this.ExecutedCommand.GetParameterAsInt("yoffset");
 
-            var pixelsPerSecond = Convert.ToInt32(this.ExecutedCommand.Parameters["speed"]);
+            var pixelsPerSecond = this.ExecutedCommand.GetParameterAsInt("speed");
 
             return TouchSimulator.FlickElement(element, xOffset, yOffset, pixelsPerSecond)
                 ? this.JsonResponse() 

--- a/src/Winium.Desktop.Driver/CommandExecutors/TouchFlickExecutor.cs
+++ b/src/Winium.Desktop.Driver/CommandExecutors/TouchFlickExecutor.cs
@@ -56,7 +56,7 @@ namespace Winium.Desktop.Driver.CommandExecutors
             }
 
             var registeredKey = this.ExecutedCommand.Parameters["element"].ToString();
-            var element = this.Automator.ElementsRegistry.GetRegisteredElementOrNull(registeredKey);
+            var element = this.Automator.ElementsRegistry.GetRegisteredElement(registeredKey);
 
             var xOffset = Convert.ToInt32(this.ExecutedCommand.Parameters["xoffset"]);
             var yOffset = Convert.ToInt32(this.ExecutedCommand.Parameters["yoffset"]);

--- a/src/Winium.Desktop.Driver/CommandExecutors/TouchFlickExecutor.cs
+++ b/src/Winium.Desktop.Driver/CommandExecutors/TouchFlickExecutor.cs
@@ -1,0 +1,73 @@
+namespace Winium.Desktop.Driver.CommandExecutors
+{
+    #region using
+
+    using System;
+    using System.Threading;
+    using System.Windows;
+
+    using Winium.Cruciatus;
+    using Winium.Cruciatus.Core;
+    using Winium.StoreApps.Common;
+
+    #endregion
+
+    internal class TouchFlickExecutor : CommandExecutorBase
+    {
+        #region Methods
+
+        protected override string DoImpl()
+        {
+            if (this.ExecutedCommand.Parameters.ContainsKey("element"))
+            {
+                return FlickElement();
+            }
+
+            return Flick();
+        }
+
+        string Flick()
+        { 
+            if (!(this.ExecutedCommand.Parameters.ContainsKey("xspeed") 
+                && this.ExecutedCommand.Parameters.ContainsKey("yspeed")))
+            {
+                // TODO: in the future '400 : invalid argument' will be used
+                return this.JsonResponse(ResponseStatus.UnknownError, "WRONG PARAMETERS");
+            }
+
+            var xSpeed = Convert.ToInt32(this.ExecutedCommand.Parameters["xspeed"]);
+            var ySpeed = Convert.ToInt32(this.ExecutedCommand.Parameters["yspeed"]);
+
+            return TouchSimulator.Flick(xSpeed, ySpeed)
+                ? this.JsonResponse()
+                : this.JsonResponse(ResponseStatus.UnknownError, "Touch input failed");
+        }
+
+        string FlickElement()
+        {
+            if (
+                !(this.ExecutedCommand.Parameters.ContainsKey("element")
+                  && this.ExecutedCommand.Parameters.ContainsKey("xoffset")
+                  && this.ExecutedCommand.Parameters.ContainsKey("yoffset")
+                  && this.ExecutedCommand.Parameters.ContainsKey("speed")))
+            {
+                // TODO: in the future '400 : invalid argument' will be used
+                return this.JsonResponse(ResponseStatus.UnknownError, "WRONG PARAMETERS");
+            }
+
+            var registeredKey = this.ExecutedCommand.Parameters["element"].ToString();
+            var element = this.Automator.ElementsRegistry.GetRegisteredElementOrNull(registeredKey);
+
+            var xOffset = Convert.ToInt32(this.ExecutedCommand.Parameters["xoffset"]);
+            var yOffset = Convert.ToInt32(this.ExecutedCommand.Parameters["yoffset"]);
+
+            var pixelsPerSecond = Convert.ToInt32(this.ExecutedCommand.Parameters["speed"]);
+
+            return TouchSimulator.FlickElement(element, xOffset, yOffset, pixelsPerSecond)
+                ? this.JsonResponse() 
+                : this.JsonResponse(ResponseStatus.UnknownError, "Touch input failed");
+        }
+
+        #endregion
+    }
+}

--- a/src/Winium.Desktop.Driver/CommandExecutors/TouchLongPressExecutor.cs
+++ b/src/Winium.Desktop.Driver/CommandExecutors/TouchLongPressExecutor.cs
@@ -1,0 +1,70 @@
+namespace Winium.Desktop.Driver.CommandExecutors
+{
+    #region using
+
+    using System;
+
+    using Winium.Cruciatus.Core;
+    using Winium.Cruciatus.Elements;
+    using Winium.StoreApps.Common;
+
+    #endregion
+
+    internal class TouchLongPressExecutor : CommandExecutorBase
+    {
+        #region Methods
+
+        protected override string DoImpl()
+        {
+            var haveElement = this.ExecutedCommand.Parameters.ContainsKey("element");
+            var havePoint = this.ExecutedCommand.Parameters.ContainsKey("x")
+                            && this.ExecutedCommand.Parameters.ContainsKey("y");
+
+            if (!(haveElement || havePoint))
+            {
+                // TODO: in the future '400 : invalid argument' will be used
+                return this.JsonResponse(ResponseStatus.UnknownError, "WRONG PARAMETERS");
+            }
+
+            bool success;
+            CruciatusElement element = null;
+            var x = 0;
+            var y = 0;
+
+            if (haveElement)
+            {
+                var registeredKey = this.ExecutedCommand.Parameters["element"].ToString();
+                element = this.Automator.ElementsRegistry.GetRegisteredElement(registeredKey);
+            }
+
+            if (havePoint)
+            {
+                x = Convert.ToInt32(this.ExecutedCommand.Parameters["x"]);
+                y = Convert.ToInt32(this.ExecutedCommand.Parameters["y"]);
+            }
+
+            var duration = this.ExecutedCommand.Parameters.ContainsKey("duration")
+                               ? Convert.ToInt32(this.ExecutedCommand.Parameters["duration"])
+                               : 1000;
+
+            if (haveElement && havePoint)
+            {
+                success = TouchSimulator.LongTap(element, x, y, duration);
+            }
+            else if (haveElement)
+            {
+                success = TouchSimulator.LongTap(element, duration);
+            }
+            else
+            {
+                success = TouchSimulator.LongTap(x, y, duration);
+            }
+
+            return success
+                ? this.JsonResponse()
+                : this.JsonResponse(ResponseStatus.UnknownError, "Touch input failed");
+        }
+
+        #endregion
+    }
+}

--- a/src/Winium.Desktop.Driver/CommandExecutors/TouchLongPressExecutor.cs
+++ b/src/Winium.Desktop.Driver/CommandExecutors/TouchLongPressExecutor.cs
@@ -6,6 +6,7 @@ namespace Winium.Desktop.Driver.CommandExecutors
 
     using Winium.Cruciatus.Core;
     using Winium.Cruciatus.Elements;
+    using Winium.Desktop.Driver.Extensions;
     using Winium.StoreApps.Common;
 
     #endregion
@@ -39,12 +40,12 @@ namespace Winium.Desktop.Driver.CommandExecutors
 
             if (havePoint)
             {
-                x = Convert.ToInt32(this.ExecutedCommand.Parameters["x"]);
-                y = Convert.ToInt32(this.ExecutedCommand.Parameters["y"]);
+                x = this.ExecutedCommand.GetParameterAsInt("x");
+                y = this.ExecutedCommand.GetParameterAsInt("y");
             }
 
             var duration = this.ExecutedCommand.Parameters.ContainsKey("duration")
-                               ? Convert.ToInt32(this.ExecutedCommand.Parameters["duration"])
+                               ? this.ExecutedCommand.GetParameterAsInt("duration")
                                : 1000;
 
             if (haveElement && havePoint)

--- a/src/Winium.Desktop.Driver/CommandExecutors/TouchMoveExecutor.cs
+++ b/src/Winium.Desktop.Driver/CommandExecutors/TouchMoveExecutor.cs
@@ -1,0 +1,35 @@
+namespace Winium.Desktop.Driver.CommandExecutors
+{
+    #region using
+
+    using System;
+
+    using Winium.Cruciatus.Core;
+    using Winium.StoreApps.Common;
+
+    #endregion
+
+    internal class TouchMoveExecutor : CommandExecutorBase
+    {
+        #region Methods
+
+        protected override string DoImpl()
+        {
+            if (!this.ExecutedCommand.Parameters.ContainsKey("x")
+                && this.ExecutedCommand.Parameters.ContainsKey("y"))
+            {
+                // TODO: in the future '400 : invalid argument' will be used
+                return this.JsonResponse(ResponseStatus.UnknownError, "WRONG PARAMETERS");
+            }
+
+            var x = Convert.ToInt32(this.ExecutedCommand.Parameters["x"]);
+            var y = Convert.ToInt32(this.ExecutedCommand.Parameters["y"]);
+
+            return TouchSimulator.TouchUpdate(x, y)
+                ? this.JsonResponse()
+                : this.JsonResponse(ResponseStatus.UnknownError, "Touch input failed");
+        }
+
+        #endregion
+    }
+}

--- a/src/Winium.Desktop.Driver/CommandExecutors/TouchMoveExecutor.cs
+++ b/src/Winium.Desktop.Driver/CommandExecutors/TouchMoveExecutor.cs
@@ -5,6 +5,7 @@ namespace Winium.Desktop.Driver.CommandExecutors
     using System;
 
     using Winium.Cruciatus.Core;
+    using Winium.Desktop.Driver.Extensions;
     using Winium.StoreApps.Common;
 
     #endregion
@@ -22,8 +23,8 @@ namespace Winium.Desktop.Driver.CommandExecutors
                 return this.JsonResponse(ResponseStatus.UnknownError, "WRONG PARAMETERS");
             }
 
-            var x = Convert.ToInt32(this.ExecutedCommand.Parameters["x"]);
-            var y = Convert.ToInt32(this.ExecutedCommand.Parameters["y"]);
+            var x = this.ExecutedCommand.GetParameterAsInt("x");
+            var y = this.ExecutedCommand.GetParameterAsInt("y");
 
             bool success;
 

--- a/src/Winium.Desktop.Driver/CommandExecutors/TouchMoveExecutor.cs
+++ b/src/Winium.Desktop.Driver/CommandExecutors/TouchMoveExecutor.cs
@@ -25,7 +25,21 @@ namespace Winium.Desktop.Driver.CommandExecutors
             var x = Convert.ToInt32(this.ExecutedCommand.Parameters["x"]);
             var y = Convert.ToInt32(this.ExecutedCommand.Parameters["y"]);
 
-            return TouchSimulator.TouchUpdate(x, y)
+            bool success;
+
+            if (this.ExecutedCommand.Parameters.ContainsKey("element"))
+            {
+                var registeredKey = this.ExecutedCommand.Parameters["element"].ToString();
+                var element = this.Automator.ElementsRegistry.GetRegisteredElement(registeredKey);
+
+                success = TouchSimulator.TouchUpdate(element, x, y);
+            }
+            else
+            {
+                success = TouchSimulator.TouchUpdate(x, y);
+            }
+
+            return success
                 ? this.JsonResponse()
                 : this.JsonResponse(ResponseStatus.UnknownError, "Touch input failed");
         }

--- a/src/Winium.Desktop.Driver/CommandExecutors/TouchPerformExecutor.cs
+++ b/src/Winium.Desktop.Driver/CommandExecutors/TouchPerformExecutor.cs
@@ -114,8 +114,10 @@
             var havePrevious = false;
             string previousAction = null;
 
-            foreach (var action in actions)
+            for (var i = 0; i < actions.Count; i ++)
             {
+                var action = actions[i];
+
                 Point point;
 
                 switch (action.Action)
@@ -126,8 +128,13 @@
                         havePrevious = false;
                         break;
                     case TouchAction.MoveTo:
+                        int? duration = null;
+                        if (i > 0 && actions[i - 1].Action == TouchAction.Wait)
+                        {
+                            duration = actions[i - 1].MiliSeconds;
+                        }
                         point = action.GetLocation();
-                        TouchSimulator.TouchUpdate((int)point.X, (int)point.Y);
+                        TouchSimulator.MoveTo(previousX, previousY, (int)point.X, (int)point.Y, duration);
                         previousX = (int)point.X;
                         previousY = (int)point.Y;
                         havePrevious = true;
@@ -153,6 +160,10 @@
                         havePrevious = false;
                         break;
                     case TouchAction.Wait:
+                        if (actions.Count > i + 1 && actions[i + 1].Action == TouchAction.MoveTo)
+                        {
+                            break;
+                        }
                         if (havePrevious)
                         {
                             var startTime = DateTime.Now;

--- a/src/Winium.Desktop.Driver/CommandExecutors/TouchPerformExecutor.cs
+++ b/src/Winium.Desktop.Driver/CommandExecutors/TouchPerformExecutor.cs
@@ -158,7 +158,11 @@
                         break;
                     case TouchAction.Tap:
                         point = action.GetLocation();
-                        TouchSimulator.Tap((int)point.X, (int)point.Y);
+                        for (var n = 1; n <= action.Count; n++)
+                        {
+                            TouchSimulator.Tap((int)point.X, (int)point.Y);
+                            Thread.Sleep(250);
+                        }
                         havePrevious = false;
                         break;
                     case TouchAction.Wait:

--- a/src/Winium.Desktop.Driver/CommandExecutors/TouchPerformExecutor.cs
+++ b/src/Winium.Desktop.Driver/CommandExecutors/TouchPerformExecutor.cs
@@ -84,8 +84,13 @@
 
                     var rect = element.Properties.BoundingRectangle;
 
-                    point.X = (int)rect.Left;
-                    point.Y = (int)rect.Top;
+                    point.X = _jsonTouchAction.Options.ContainsKey("x")
+                                  ? rect.Left
+                                  : (rect.Left + (rect.Width / 2));
+
+                    point.Y = _jsonTouchAction.Options.ContainsKey("y")
+                                  ? rect.Top
+                                  : (rect.Top + (rect.Height / 2));
                 }
 
                 if (_jsonTouchAction.Options.ContainsKey("x"))

--- a/src/Winium.Desktop.Driver/CommandExecutors/TouchPerformExecutor.cs
+++ b/src/Winium.Desktop.Driver/CommandExecutors/TouchPerformExecutor.cs
@@ -1,0 +1,271 @@
+﻿namespace Winium.Desktop.Driver.CommandExecutors
+{
+    #region using
+
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Windows;
+
+    using Winium.StoreApps.Common;
+    using Newtonsoft.Json;
+
+    using Winium.Cruciatus.Core;
+    using Winium.Cruciatus.Elements;
+    using Winium.Desktop.Driver.Automator;
+    using Winium.StoreApps.Common.Exceptions;
+
+    #endregion
+
+    internal class TouchPerformExecutor : CommandExecutorBase
+    {
+
+        #region Inner classes
+
+        class JsonTouchAction
+        {
+            CruciatusElement element;
+
+            [JsonProperty("action")]
+            public string Action { get; set; }
+
+            [JsonProperty("options")]
+            public Dictionary<string, string> Options { get; set; }
+        }
+
+        class TouchAction
+        {
+            public const string LongPress = "longpress";
+            public const string MoveTo = "moveto";
+            public const string Press = "press";
+            public const string Release = "release";
+            public const string Tap = "tap";
+            public const string Wait = "wait";
+
+            JsonTouchAction _jsonTouchAction;
+
+            Automator _automator;
+
+            public TouchAction(JsonTouchAction jsonTouchAction, Automator automator)
+            {
+                _jsonTouchAction = jsonTouchAction;
+                _automator = automator;
+
+                if (this.Action == Wait)
+                {
+                    this.MiliSeconds = Convert.ToInt32(jsonTouchAction.Options["ms"]);
+                    return;
+                }
+
+                if (this.Action == Release)
+                {
+                    return;
+                }
+
+                if (this.Action == LongPress)
+                {
+                    this.MiliSeconds = jsonTouchAction.Options.ContainsKey("duration")
+                        ? Convert.ToInt32(jsonTouchAction.Options["duration"])
+                        : 1000;
+                }
+            }
+
+            public string Action => _jsonTouchAction.Action.ToLower();
+
+            public Point GetLocation()
+            {
+                var point = new Point();
+
+                if (_jsonTouchAction.Options.ContainsKey("element"))
+                {
+                    var element = _automator.ElementsRegistry.GetRegisteredElement(
+                        _jsonTouchAction.Options["element"]);
+
+                    var rect = element.Properties.BoundingRectangle;
+
+                    point.X = (int)rect.Left;
+                    point.Y = (int)rect.Top;
+                }
+
+                if (_jsonTouchAction.Options.ContainsKey("x"))
+                {
+                    point.X += Convert.ToInt32(_jsonTouchAction.Options["x"]);
+                }
+
+                if (_jsonTouchAction.Options.ContainsKey("y"))
+                {
+                    point.Y += Convert.ToInt32(_jsonTouchAction.Options["y"]);
+                }
+
+                return point;
+            }
+
+            public int MiliSeconds { get; }
+        }
+
+        #endregion
+
+        #region Methods
+
+        protected override string DoImpl()
+        {
+            if (!this.ExecutedCommand.Parameters.ContainsKey("actions"))
+            {
+                // TODO: in the future '400 : invalid argument' will be used
+                return this.JsonResponse(ResponseStatus.UnknownError, "WRONG PARAMETERS");
+            }
+
+            var actions = this.ExecutedCommand.Parameters["actions"]
+                .ToObject<List<JsonTouchAction>>()
+                .Select(a => new TouchAction(a, this.Automator))
+                .ToList();
+
+            var success = false;
+
+            if (actions.Count == 4 
+                && actions[0].Action == TouchAction.Press
+                && actions[1].Action == TouchAction.Wait
+                && actions[2].Action == TouchAction.MoveTo
+                && actions[3].Action == TouchAction.Release)
+            {
+                success = Flick(actions);
+            }
+            else if (actions.Count == 5
+                && actions[0].Action == TouchAction.Press
+                && actions[1].Action == TouchAction.Wait
+                && actions[2].Action == TouchAction.MoveTo 
+                && actions[3].Action == TouchAction.Wait
+                && actions[4].Action == TouchAction.Release)
+            {
+                success = DragWithTimes(actions);
+            }
+            else if (actions.Count == 3
+                && actions[0].Action == TouchAction.LongPress
+                && actions[1].Action == TouchAction.MoveTo
+                && actions[2].Action == TouchAction.Release)
+            {
+                success = Drag(actions);
+            }
+            else
+            {
+                success = Perform(actions);
+            }
+
+            return success
+                ? this.JsonResponse()
+                : this.JsonResponse(ResponseStatus.UnknownError, "Touch input failed");
+        }
+
+        private static bool Flick(List<TouchAction> actions)
+        {
+            var startPoint = actions[0].GetLocation();
+            var endPoint = actions[2].GetLocation();
+
+            return TouchSimulator.Flick(
+                (int)startPoint.X,
+                (int)startPoint.Y,
+                (int)endPoint.X,
+                (int)endPoint.Y,
+                actions[1].MiliSeconds);
+        }
+
+        private static bool DragWithTimes(List<TouchAction> actions)
+        {
+            var startPoint = actions[0].GetLocation();
+            var endPoint = actions[2].GetLocation();
+
+            return TouchSimulator.Scroll(
+                (int)startPoint.X,
+                (int)startPoint.Y,
+                (int)endPoint.X,
+                (int)endPoint.Y,
+                actions[1].MiliSeconds,
+                actions[3].MiliSeconds);
+        }
+
+        private static bool Drag(List<TouchAction> actions)
+        {
+            var startPoint = actions[0].GetLocation();
+            var endPoint = actions[1].GetLocation();
+
+            return TouchSimulator.Scroll(
+                (int)startPoint.X,
+                (int)startPoint.Y,
+                (int)endPoint.X,
+                (int)endPoint.Y);
+        }
+
+        private static bool Perform(List<TouchAction> actions)
+        {
+            var previousX = 0;
+            var previousY = 0;
+            var havePrevious = false;
+            string previousAction = null;
+
+            foreach (var action in actions)
+            {
+                Point point;
+
+                switch (action.Action)
+                {
+                    case TouchAction.LongPress:
+                        point = action.GetLocation();
+                        TouchSimulator.LongTap((int)point.X, (int)point.Y, action.MiliSeconds);
+                        havePrevious = false;
+                        break;
+                    case TouchAction.MoveTo:
+                        point = action.GetLocation();
+                        TouchSimulator.TouchUpdate((int)point.X, (int)point.Y);
+                        previousX = (int)point.X;
+                        previousY = (int)point.Y;
+                        havePrevious = true;
+                        break;
+                    case TouchAction.Press:
+                        point = action.GetLocation();
+                        TouchSimulator.TouchDown((int)point.X, (int)point.Y);
+                        previousX = (int)point.X;
+                        previousY = (int)point.Y;
+                        havePrevious = true;
+                        break;
+                    case TouchAction.Release:
+                        if (previousAction == TouchAction.Tap || previousAction == TouchAction.LongPress)
+                        {
+                            break;
+                        }
+                        TouchSimulator.TouchUp(previousX, previousY);
+                        havePrevious = false;
+                        break;
+                    case TouchAction.Tap:
+                        point = action.GetLocation();
+                        TouchSimulator.Tap((int)point.X, (int)point.Y);
+                        havePrevious = false;
+                        break;
+                    case TouchAction.Wait:
+                        if (havePrevious)
+                        {
+                            var startTime = DateTime.Now;
+                            while (DateTime.Now < startTime + TimeSpan.FromMilliseconds(action.MiliSeconds))
+                            {
+                                TouchSimulator.TouchUpdate(previousX, previousY);
+                                Thread.Sleep(16);
+                            }
+                        }
+                        else
+                        {
+                            Thread.Sleep(action.MiliSeconds);
+                        }
+                        break;
+                    default:
+                        throw new AutomationException($"unrecognised action {action.Action}");
+                }
+
+                previousAction = action.Action;
+            }
+
+            return true;
+        }
+
+        #endregion
+    }
+}

--- a/src/Winium.Desktop.Driver/CommandExecutors/TouchPerformExecutor.cs
+++ b/src/Winium.Desktop.Driver/CommandExecutors/TouchPerformExecutor.cs
@@ -134,9 +134,11 @@
                             duration = actions[i - 1].MiliSeconds;
                         }
                         point = action.GetLocation();
-                        TouchSimulator.MoveTo(previousX, previousY, (int)point.X, (int)point.Y, duration);
-                        previousX = (int)point.X;
-                        previousY = (int)point.Y;
+                        var x = (int)point.X;
+                        var y = (int)point.Y;
+                        TouchSimulator.MoveTo(previousX, previousY, previousX + x, previousY + y, duration);
+                        previousX += x;
+                        previousY += y;
                         havePrevious = true;
                         break;
                     case TouchAction.Press:

--- a/src/Winium.Desktop.Driver/CommandExecutors/TouchPerformExecutor.cs
+++ b/src/Winium.Desktop.Driver/CommandExecutors/TouchPerformExecutor.cs
@@ -9,108 +9,14 @@
     using System.Windows;
 
     using Winium.StoreApps.Common;
-    using Newtonsoft.Json;
-
     using Winium.Cruciatus.Core;
-    using Winium.Cruciatus.Elements;
-    using Winium.Desktop.Driver.Automator;
+    using Winium.Desktop.Driver.CommandHelpers;
     using Winium.StoreApps.Common.Exceptions;
 
     #endregion
 
     internal class TouchPerformExecutor : CommandExecutorBase
     {
-
-        #region Inner classes
-
-        class JsonTouchAction
-        {
-            CruciatusElement element;
-
-            [JsonProperty("action")]
-            public string Action { get; set; }
-
-            [JsonProperty("options")]
-            public Dictionary<string, string> Options { get; set; }
-        }
-
-        class TouchAction
-        {
-            public const string LongPress = "longpress";
-            public const string MoveTo = "moveto";
-            public const string Press = "press";
-            public const string Release = "release";
-            public const string Tap = "tap";
-            public const string Wait = "wait";
-
-            JsonTouchAction _jsonTouchAction;
-
-            Automator _automator;
-
-            public TouchAction(JsonTouchAction jsonTouchAction, Automator automator)
-            {
-                _jsonTouchAction = jsonTouchAction;
-                _automator = automator;
-
-                if (this.Action == Wait)
-                {
-                    this.MiliSeconds = Convert.ToInt32(jsonTouchAction.Options["ms"]);
-                    return;
-                }
-
-                if (this.Action == Release)
-                {
-                    return;
-                }
-
-                if (this.Action == LongPress)
-                {
-                    this.MiliSeconds = jsonTouchAction.Options.ContainsKey("duration")
-                        ? Convert.ToInt32(jsonTouchAction.Options["duration"])
-                        : 1000;
-                }
-            }
-
-            public string Action => _jsonTouchAction.Action.ToLower();
-
-            public Point GetLocation()
-            {
-                var point = new Point();
-
-                if (_jsonTouchAction.Options.ContainsKey("element"))
-                {
-                    var element = _automator.ElementsRegistry.GetRegisteredElement(
-                        _jsonTouchAction.Options["element"]);
-
-                    var rect = element.Properties.BoundingRectangle;
-
-                    point.X = _jsonTouchAction.Options.ContainsKey("x")
-                                  ? rect.Left
-                                  : (rect.Left + (rect.Width / 2));
-
-                    point.Y = _jsonTouchAction.Options.ContainsKey("y")
-                                  ? rect.Top
-                                  : (rect.Top + (rect.Height / 2));
-                }
-
-                if (_jsonTouchAction.Options.ContainsKey("x"))
-                {
-                    point.X += Convert.ToInt32(_jsonTouchAction.Options["x"]);
-                }
-
-                if (_jsonTouchAction.Options.ContainsKey("y"))
-                {
-                    point.Y += Convert.ToInt32(_jsonTouchAction.Options["y"]);
-                }
-
-                return point;
-            }
-
-            public int MiliSeconds { get; }
-        }
-
-        #endregion
-
         #region Methods
 
         protected override string DoImpl()

--- a/src/Winium.Desktop.Driver/CommandExecutors/TouchPressExecutor.cs
+++ b/src/Winium.Desktop.Driver/CommandExecutors/TouchPressExecutor.cs
@@ -25,7 +25,21 @@
             var x = Convert.ToInt32(this.ExecutedCommand.Parameters["x"]);
             var y = Convert.ToInt32(this.ExecutedCommand.Parameters["y"]);
 
-            return TouchSimulator.TouchDown(x, y)
+            bool success;
+
+            if (this.ExecutedCommand.Parameters.ContainsKey("element"))
+            {
+                var registeredKey = this.ExecutedCommand.Parameters["element"].ToString();
+                var element = this.Automator.ElementsRegistry.GetRegisteredElement(registeredKey);
+
+                success = TouchSimulator.TouchDown(element, x, y);
+            }
+            else
+            {
+                success = TouchSimulator.TouchDown(x, y);
+            }
+
+            return success
                 ? this.JsonResponse()
                 : this.JsonResponse(ResponseStatus.UnknownError, "Touch input failed");
         }

--- a/src/Winium.Desktop.Driver/CommandExecutors/TouchPressExecutor.cs
+++ b/src/Winium.Desktop.Driver/CommandExecutors/TouchPressExecutor.cs
@@ -5,6 +5,7 @@
     using System;
 
     using Winium.Cruciatus.Core;
+    using Winium.Desktop.Driver.Extensions;
     using Winium.StoreApps.Common;
 
     #endregion
@@ -22,8 +23,8 @@
                 return this.JsonResponse(ResponseStatus.UnknownError, "WRONG PARAMETERS");
             }
 
-            var x = Convert.ToInt32(this.ExecutedCommand.Parameters["x"]);
-            var y = Convert.ToInt32(this.ExecutedCommand.Parameters["y"]);
+            var x = this.ExecutedCommand.GetParameterAsInt("x");
+            var y = this.ExecutedCommand.GetParameterAsInt("y");
 
             bool success;
 

--- a/src/Winium.Desktop.Driver/CommandExecutors/TouchPressExecutor.cs
+++ b/src/Winium.Desktop.Driver/CommandExecutors/TouchPressExecutor.cs
@@ -1,0 +1,35 @@
+﻿namespace Winium.Desktop.Driver.CommandExecutors
+{
+    #region using
+
+    using System;
+
+    using Winium.Cruciatus.Core;
+    using Winium.StoreApps.Common;
+
+    #endregion
+
+    internal class TouchPressExecutor : CommandExecutorBase
+    {
+        #region Methods
+
+        protected override string DoImpl()
+        {
+            if (!this.ExecutedCommand.Parameters.ContainsKey("x")
+                && this.ExecutedCommand.Parameters.ContainsKey("y"))
+            {
+                // TODO: in the future '400 : invalid argument' will be used
+                return this.JsonResponse(ResponseStatus.UnknownError, "WRONG PARAMETERS");
+            }
+
+            var x = Convert.ToInt32(this.ExecutedCommand.Parameters["x"]);
+            var y = Convert.ToInt32(this.ExecutedCommand.Parameters["y"]);
+
+            return TouchSimulator.TouchDown(x, y)
+                ? this.JsonResponse()
+                : this.JsonResponse(ResponseStatus.UnknownError, "Touch input failed");
+        }
+
+        #endregion
+    }
+}

--- a/src/Winium.Desktop.Driver/CommandExecutors/TouchReleaseExecutor.cs
+++ b/src/Winium.Desktop.Driver/CommandExecutors/TouchReleaseExecutor.cs
@@ -5,6 +5,7 @@ namespace Winium.Desktop.Driver.CommandExecutors
     using System;
 
     using Winium.Cruciatus.Core;
+    using Winium.Desktop.Driver.Extensions;
     using Winium.StoreApps.Common;
 
     #endregion
@@ -22,8 +23,8 @@ namespace Winium.Desktop.Driver.CommandExecutors
                 return this.JsonResponse(ResponseStatus.UnknownError, "WRONG PARAMETERS");
             }
 
-            var x = Convert.ToInt32(this.ExecutedCommand.Parameters["x"]);
-            var y = Convert.ToInt32(this.ExecutedCommand.Parameters["y"]);
+            var x = this.ExecutedCommand.GetParameterAsInt("x");
+            var y = this.ExecutedCommand.GetParameterAsInt("y");
 
             bool success;
 

--- a/src/Winium.Desktop.Driver/CommandExecutors/TouchReleaseExecutor.cs
+++ b/src/Winium.Desktop.Driver/CommandExecutors/TouchReleaseExecutor.cs
@@ -25,7 +25,21 @@ namespace Winium.Desktop.Driver.CommandExecutors
             var x = Convert.ToInt32(this.ExecutedCommand.Parameters["x"]);
             var y = Convert.ToInt32(this.ExecutedCommand.Parameters["y"]);
 
-            return TouchSimulator.TouchUp(x, y)
+            bool success;
+
+            if (this.ExecutedCommand.Parameters.ContainsKey("element"))
+            {
+                var registeredKey = this.ExecutedCommand.Parameters["element"].ToString();
+                var element = this.Automator.ElementsRegistry.GetRegisteredElement(registeredKey);
+
+                success = TouchSimulator.TouchUp(element, x, y);
+            }
+            else
+            {
+                success = TouchSimulator.TouchUp(x, y);
+            }
+
+            return success
                 ? this.JsonResponse()
                 : this.JsonResponse(ResponseStatus.UnknownError, "Touch input failed ('x' and 'y' must match preceeding 'down' or 'move' request)");
         }

--- a/src/Winium.Desktop.Driver/CommandExecutors/TouchReleaseExecutor.cs
+++ b/src/Winium.Desktop.Driver/CommandExecutors/TouchReleaseExecutor.cs
@@ -1,0 +1,35 @@
+namespace Winium.Desktop.Driver.CommandExecutors
+{
+    #region using
+
+    using System;
+
+    using Winium.Cruciatus.Core;
+    using Winium.StoreApps.Common;
+
+    #endregion
+
+    internal class TouchReleaseExecutor : CommandExecutorBase
+    {
+        #region Methods
+
+        protected override string DoImpl()
+        {
+            if (!this.ExecutedCommand.Parameters.ContainsKey("x")
+                && this.ExecutedCommand.Parameters.ContainsKey("y"))
+            {
+                // TODO: in the future '400 : invalid argument' will be used
+                return this.JsonResponse(ResponseStatus.UnknownError, "WRONG PARAMETERS");
+            }
+
+            var x = Convert.ToInt32(this.ExecutedCommand.Parameters["x"]);
+            var y = Convert.ToInt32(this.ExecutedCommand.Parameters["y"]);
+
+            return TouchSimulator.TouchUp(x, y)
+                ? this.JsonResponse()
+                : this.JsonResponse(ResponseStatus.UnknownError, "Touch input failed ('x' and 'y' must match preceeding 'down' or 'move' request)");
+        }
+
+        #endregion
+    }
+}

--- a/src/Winium.Desktop.Driver/CommandExecutors/TouchScrollExecutor.cs
+++ b/src/Winium.Desktop.Driver/CommandExecutors/TouchScrollExecutor.cs
@@ -8,6 +8,7 @@ namespace Winium.Desktop.Driver.CommandExecutors
 
     using Winium.Cruciatus;
     using Winium.Cruciatus.Core;
+    using Winium.Desktop.Driver.Extensions;
     using Winium.StoreApps.Common;
 
     #endregion
@@ -42,8 +43,8 @@ namespace Winium.Desktop.Driver.CommandExecutors
                 rect.Left + (rect.Width / 2), 
                 rect.Top + (rect.Height / 2));
 
-            var xOffset = Convert.ToInt32(this.ExecutedCommand.Parameters["xoffset"]);
-            var yOffset = Convert.ToInt32(this.ExecutedCommand.Parameters["yoffset"]);
+            var xOffset = this.ExecutedCommand.GetParameterAsInt("xoffset");
+            var yOffset = this.ExecutedCommand.GetParameterAsInt("yoffset");
 
             var endPoint = new Point(
                 startPoint.X + xOffset,

--- a/src/Winium.Desktop.Driver/CommandExecutors/TouchScrollExecutor.cs
+++ b/src/Winium.Desktop.Driver/CommandExecutors/TouchScrollExecutor.cs
@@ -1,0 +1,90 @@
+namespace Winium.Desktop.Driver.CommandExecutors
+{
+    #region using
+
+    using System;
+    using System.Threading;
+    using System.Windows;
+
+    using Winium.Cruciatus;
+    using Winium.Cruciatus.Core;
+    using Winium.StoreApps.Common;
+
+    #endregion
+
+    internal class TouchScrollExecutor : CommandExecutorBase
+    {
+        #region Methods
+
+        protected override string DoImpl()
+        {
+            var haveElement = this.ExecutedCommand.Parameters.ContainsKey("element");
+            var haveOffset = this.ExecutedCommand.Parameters.ContainsKey("xoffset")
+                             && this.ExecutedCommand.Parameters.ContainsKey("yoffset");
+
+            if (!haveOffset)
+            {
+                // TODO: in the future '400 : invalid argument' will be used
+                return this.JsonResponse(ResponseStatus.UnknownError, "WRONG PARAMETERS");
+            }
+
+            var element = CruciatusFactory.Root;
+
+            if (haveElement)
+            {
+                var registeredKey = this.ExecutedCommand.Parameters["element"].ToString();
+                element = this.Automator.ElementsRegistry.GetRegisteredElement(registeredKey);
+            }
+
+            var rect = element.Properties.BoundingRectangle;
+
+            var startPoint = new Point(
+                rect.Left + (rect.Width / 2), 
+                rect.Top + (rect.Height / 2));
+
+            var xOffset = Convert.ToInt32(this.ExecutedCommand.Parameters["xoffset"]);
+            var yOffset = Convert.ToInt32(this.ExecutedCommand.Parameters["yoffset"]);
+
+            var endPoint = new Point(
+                startPoint.X + xOffset,
+                startPoint.Y + yOffset);
+
+            if (!TouchSimulator.TouchDown((int)startPoint.X, (int)startPoint.Y))
+            {
+                return this.JsonResponse(ResponseStatus.UnknownError, "Touch input failed");
+            }
+
+            var distance = Math.Sqrt(Math.Pow(startPoint.X - endPoint.X, 2) + Math.Pow(startPoint.Y - endPoint.Y, 2));
+
+            for (var soFar = 6; soFar < distance; soFar += 6)
+            {
+                var soFarFraction = soFar / distance;
+
+                var x = (int)(startPoint.X + (xOffset * soFarFraction));
+                var y = (int)(startPoint.Y + (yOffset * soFarFraction));
+                if (!TouchSimulator.TouchUpdate(x, y))
+                {
+                    return this.JsonResponse(ResponseStatus.UnknownError, "Touch input failed");
+                }
+
+                Thread.Sleep(8);
+            }
+
+            var startTime = DateTime.Now;
+            while (DateTime.Now < (startTime + TimeSpan.FromMilliseconds(500)))
+            {
+                if (!TouchSimulator.TouchUpdate((int)endPoint.X, (int)endPoint.Y))
+                {
+                    return this.JsonResponse(ResponseStatus.UnknownError, "Touch input failed");
+                }
+                Thread.Sleep(16);
+            }
+
+            return TouchSimulator.TouchUp((int)endPoint.X, (int)endPoint.Y)
+                ? this.JsonResponse()
+                : this.JsonResponse(ResponseStatus.UnknownError, "Touch input failed");
+        }
+
+        #endregion
+    }
+}

--- a/src/Winium.Desktop.Driver/CommandExecutors/TouchSingleTapExecutor.cs
+++ b/src/Winium.Desktop.Driver/CommandExecutors/TouchSingleTapExecutor.cs
@@ -1,0 +1,32 @@
+﻿namespace Winium.Desktop.Driver.CommandExecutors
+{
+    #region using
+
+    using Winium.Cruciatus.Core;
+    using Winium.StoreApps.Common;
+
+    #endregion
+
+    internal class TouchSingleTapExecutor : CommandExecutorBase
+    {
+        #region Methods
+
+        protected override string DoImpl()
+        {
+            if (!ExecutedCommand.Parameters.ContainsKey("element"))
+            {
+                // TODO: in the future '400 : invalid argument' will be used
+                return this.JsonResponse(ResponseStatus.UnknownError, "WRONG PARAMETERS");
+            }
+
+            var registeredKey = this.ExecutedCommand.Parameters["element"].ToString();
+            var element = this.Automator.ElementsRegistry.GetRegisteredElement(registeredKey);
+
+            return TouchSimulator.Tap(element)
+                ? this.JsonResponse()
+                : this.JsonResponse(ResponseStatus.UnknownError, "Touch input failed");
+        }
+
+        #endregion
+    }
+}

--- a/src/Winium.Desktop.Driver/CommandHelpers/JsonTouchAction.cs
+++ b/src/Winium.Desktop.Driver/CommandHelpers/JsonTouchAction.cs
@@ -2,6 +2,7 @@
 {
     #region usings
 
+    using System;
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
@@ -16,6 +17,11 @@
 
         [JsonProperty("options")]
         public Dictionary<string, string> Options { get; set; }
+
+        public int GetOptionAsInt(string optionName)
+        {
+            return (int)Math.Round(Convert.ToDouble(Options[optionName]));
+        }
 
         #endregion
     }

--- a/src/Winium.Desktop.Driver/CommandHelpers/JsonTouchAction.cs
+++ b/src/Winium.Desktop.Driver/CommandHelpers/JsonTouchAction.cs
@@ -1,0 +1,22 @@
+﻿namespace Winium.Desktop.Driver.CommandHelpers
+{
+    #region usings
+
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    #endregion
+
+    class JsonTouchAction
+    {
+        #region Public Properties
+
+        [JsonProperty("action")]
+        public string Action { get; set; }
+
+        [JsonProperty("options")]
+        public Dictionary<string, string> Options { get; set; }
+
+        #endregion
+    }
+}

--- a/src/Winium.Desktop.Driver/CommandHelpers/TouchAction.cs
+++ b/src/Winium.Desktop.Driver/CommandHelpers/TouchAction.cs
@@ -1,0 +1,102 @@
+﻿namespace Winium.Desktop.Driver.CommandHelpers
+{
+    #region using
+
+    using System;
+    using System.Windows;
+
+    using Winium.Desktop.Driver.Automator;
+
+    #endregion
+
+    class TouchAction
+    {
+        #region Fields
+
+        JsonTouchAction _jsonTouchAction;
+
+        Automator _automator;
+
+        #endregion
+
+        #region Public Constants
+        
+        public const string LongPress = "longpress";
+        public const string MoveTo = "moveto";
+        public const string Press = "press";
+        public const string Release = "release";
+        public const string Tap = "tap";
+        public const string Wait = "wait";
+
+        #endregion
+
+        #region Public Properties
+
+        public string Action => _jsonTouchAction.Action.ToLower();
+
+        public int MiliSeconds { get; }
+
+        #endregion
+
+        #region Public Methods
+
+        public TouchAction(JsonTouchAction jsonTouchAction, Automator automator)
+        {
+            _jsonTouchAction = jsonTouchAction;
+            _automator = automator;
+
+            if (this.Action == Wait)
+            {
+                this.MiliSeconds = Convert.ToInt32(jsonTouchAction.Options["ms"]);
+                return;
+            }
+
+            if (this.Action == Release)
+            {
+                return;
+            }
+
+            if (this.Action == LongPress)
+            {
+                this.MiliSeconds = jsonTouchAction.Options.ContainsKey("duration")
+                    ? Convert.ToInt32(jsonTouchAction.Options["duration"])
+                    : 1000;
+            }
+        }
+
+        public Point GetLocation()
+        {
+            var point = new Point();
+
+            if (_jsonTouchAction.Options.ContainsKey("element"))
+            {
+                var element = _automator.ElementsRegistry.GetRegisteredElement(
+                    _jsonTouchAction.Options["element"]);
+
+                var rect = element.Properties.BoundingRectangle;
+
+                point.X = _jsonTouchAction.Options.ContainsKey("x")
+                              ? rect.Left
+                              : (rect.Left + (rect.Width / 2));
+
+                point.Y = _jsonTouchAction.Options.ContainsKey("y")
+                              ? rect.Top
+                              : (rect.Top + (rect.Height / 2));
+            }
+
+            if (_jsonTouchAction.Options.ContainsKey("x"))
+            {
+                point.X += Convert.ToInt32(_jsonTouchAction.Options["x"]);
+            }
+
+            if (_jsonTouchAction.Options.ContainsKey("y"))
+            {
+                point.Y += Convert.ToInt32(_jsonTouchAction.Options["y"]);
+            }
+
+            return point;
+        }
+
+        #endregion
+    }
+}

--- a/src/Winium.Desktop.Driver/CommandHelpers/TouchAction.cs
+++ b/src/Winium.Desktop.Driver/CommandHelpers/TouchAction.cs
@@ -36,6 +36,8 @@
 
         public int MiliSeconds { get; }
 
+        public int Count { get; }
+
         #endregion
 
         #region Public Methods
@@ -54,6 +56,12 @@
             if (this.Action == Release)
             {
                 return;
+            }
+
+            if (this.Action == Tap)
+            {
+                int count;
+                this.Count = int.TryParse(jsonTouchAction.Options["count"], out count) ? count : 1;
             }
 
             if (this.Action == LongPress)

--- a/src/Winium.Desktop.Driver/CommandHelpers/TouchAction.cs
+++ b/src/Winium.Desktop.Driver/CommandHelpers/TouchAction.cs
@@ -49,7 +49,7 @@
 
             if (this.Action == Wait)
             {
-                this.MiliSeconds = Convert.ToInt32(jsonTouchAction.Options["ms"]);
+                this.MiliSeconds = jsonTouchAction.GetOptionAsInt("ms");
                 return;
             }
 
@@ -67,7 +67,7 @@
             if (this.Action == LongPress)
             {
                 this.MiliSeconds = jsonTouchAction.Options.ContainsKey("duration")
-                    ? Convert.ToInt32(jsonTouchAction.Options["duration"])
+                    ? jsonTouchAction.GetOptionAsInt("duration")
                     : 1000;
             }
         }
@@ -94,12 +94,12 @@
 
             if (_jsonTouchAction.Options.ContainsKey("x"))
             {
-                point.X += Convert.ToInt32(_jsonTouchAction.Options["x"]);
+                point.X += _jsonTouchAction.GetOptionAsInt("x");
             }
 
             if (_jsonTouchAction.Options.ContainsKey("y"))
             {
-                point.Y += Convert.ToInt32(_jsonTouchAction.Options["y"]);
+                point.Y += _jsonTouchAction.GetOptionAsInt("y");
             }
 
             return point;

--- a/src/Winium.Desktop.Driver/Extensions/CommandHelper.cs
+++ b/src/Winium.Desktop.Driver/Extensions/CommandHelper.cs
@@ -1,0 +1,18 @@
+﻿namespace Winium.Desktop.Driver.Extensions
+{
+    #region using
+
+    using System;
+
+    using Winium.StoreApps.Common;
+
+    #endregion
+
+    public static class CommandHelper
+    {
+        public static int GetParameterAsInt(this Command command, string propertyName)
+        {
+            return (int)Math.Round(Convert.ToDouble(command.Parameters[propertyName]));
+        }
+    }
+}

--- a/src/Winium.Desktop.Driver/HttpRequest.cs
+++ b/src/Winium.Desktop.Driver/HttpRequest.cs
@@ -59,7 +59,11 @@
         private static string ReadContent(TextReader textReader, int contentLength)
         {
             var readBuffer = new char[contentLength];
-            textReader.Read(readBuffer, 0, readBuffer.Length);
+            var bytesRead = 0;
+            while (bytesRead < contentLength)
+            {
+                bytesRead += textReader.Read(readBuffer, bytesRead, contentLength - bytesRead);
+            }
             return readBuffer.Aggregate(string.Empty, (current, ch) => current + ch);
         }
 

--- a/src/Winium.Desktop.Driver/Listener.cs
+++ b/src/Winium.Desktop.Driver/Listener.cs
@@ -90,7 +90,24 @@
                     // Get a stream object for reading and writing
                     using (var stream = client.GetStream())
                     {
-                        var acceptedRequest = HttpRequest.ReadFromStreamWithoutClosing(stream);
+                        stream.ReadTimeout = 60 * 1000;
+
+                        HttpRequest acceptedRequest;
+
+                        try
+                        {
+                            acceptedRequest = HttpRequest.ReadFromStreamWithoutClosing(stream);
+                        }
+                        catch (IOException ex)
+                        {
+                            Logger.Error("Error occured while reading request: {0}", ex);
+
+                            client.Close();
+                            Logger.Debug("Client closed\n");
+
+                            continue;
+                        }
+
                         Logger.Debug("ACCEPTED REQUEST {0}", acceptedRequest.StartingLine);
 
                         var response = this.HandleRequest(acceptedRequest);

--- a/src/Winium.Desktop.Driver/UriDispatchTables.cs
+++ b/src/Winium.Desktop.Driver/UriDispatchTables.cs
@@ -286,7 +286,14 @@
             this.commandDictionary.Add(
                 DriverCommand.TouchFlick,
                 new CommandInfo("POST", "/session/{sessionId}/touch/flick"));
+            this.commandDictionary.Add(
+                DriverCommand.TouchPerform,
+                new CommandInfo("POST", "/session/{sessionId}/touch/perform"));
+            this.commandDictionary.Add(
+                DriverCommand.TouchMultiPerform,
+                new CommandInfo("POST", "/session/{sessionId}/touch/multi/perform"));
             this.commandDictionary.Add(DriverCommand.UploadFile, new CommandInfo("POST", "/session/{sessionId}/file"));
+
         }
 
         private void InitializeWiniumCommandDictionary()

--- a/src/Winium.Desktop.Driver/Winium.Desktop.Driver.csproj
+++ b/src/Winium.Desktop.Driver/Winium.Desktop.Driver.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Automator\Capabilities.cs" />
     <Compile Include="CommandExecutors\CollapseComboBoxExecutor.cs" />
     <Compile Include="CommandExecutors\FindComboBoxSelectedItemExecutor.cs" />
+    <Compile Include="CommandExecutors\GetElementLocationExecutor.cs" />
     <Compile Include="CommandExecutors\GetWindowHandlesExecutor.cs" />
     <Compile Include="CommandExecutors\GetCurrentWindowHandleExecutor.cs" />
     <Compile Include="CommandExecutors\GetDataGridRowCountExecutor.cs" />

--- a/src/Winium.Desktop.Driver/Winium.Desktop.Driver.csproj
+++ b/src/Winium.Desktop.Driver/Winium.Desktop.Driver.csproj
@@ -133,6 +133,7 @@
     <Compile Include="ElementsRegistry.cs" />
     <Compile Include="Extensions\AutomationPropertyHelper.cs" />
     <Compile Include="Extensions\ByHelper.cs" />
+    <Compile Include="Extensions\CommandHelper.cs" />
     <Compile Include="HttpRequest.cs" />
     <Compile Include="CommandExecutors\IsElementSelectedExecutor.cs" />
     <Compile Include="Input\KeyboardModifiers.cs" />

--- a/src/Winium.Desktop.Driver/Winium.Desktop.Driver.csproj
+++ b/src/Winium.Desktop.Driver/Winium.Desktop.Driver.csproj
@@ -113,6 +113,14 @@
     <Compile Include="CommandExecutors\NewSessionExecutor.cs" />
     <Compile Include="CommandExecutors\NotImplementedExecutor.cs" />
     <Compile Include="CommandExecutors\SwitchToWindowExecutor.cs" />
+    <Compile Include="CommandExecutors\TouchDoubleTapExecutor.cs" />
+    <Compile Include="CommandExecutors\TouchFlickExecutor.cs" />
+    <Compile Include="CommandExecutors\TouchLongPressExecutor.cs" />
+    <Compile Include="CommandExecutors\TouchMoveExecutor.cs" />
+    <Compile Include="CommandExecutors\TouchPressExecutor.cs" />
+    <Compile Include="CommandExecutors\TouchReleaseExecutor.cs" />
+    <Compile Include="CommandExecutors\TouchScrollExecutor.cs" />
+    <Compile Include="CommandExecutors\TouchSingleTapExecutor.cs" />
     <Compile Include="CommandLineOptions.cs" />
     <Compile Include="ElementsRegistry.cs" />
     <Compile Include="Extensions\AutomationPropertyHelper.cs" />

--- a/src/Winium.Desktop.Driver/Winium.Desktop.Driver.csproj
+++ b/src/Winium.Desktop.Driver/Winium.Desktop.Driver.csproj
@@ -127,6 +127,8 @@
     <Compile Include="CommandExecutors\TouchReleaseExecutor.cs" />
     <Compile Include="CommandExecutors\TouchScrollExecutor.cs" />
     <Compile Include="CommandExecutors\TouchSingleTapExecutor.cs" />
+    <Compile Include="CommandHelpers\JsonTouchAction.cs" />
+    <Compile Include="CommandHelpers\TouchAction.cs" />
     <Compile Include="CommandLineOptions.cs" />
     <Compile Include="ElementsRegistry.cs" />
     <Compile Include="Extensions\AutomationPropertyHelper.cs" />

--- a/src/Winium.Desktop.Driver/Winium.Desktop.Driver.csproj
+++ b/src/Winium.Desktop.Driver/Winium.Desktop.Driver.csproj
@@ -118,6 +118,7 @@
     <Compile Include="CommandExecutors\TouchFlickExecutor.cs" />
     <Compile Include="CommandExecutors\TouchLongPressExecutor.cs" />
     <Compile Include="CommandExecutors\TouchMoveExecutor.cs" />
+    <Compile Include="CommandExecutors\TouchPerformExecutor.cs" />
     <Compile Include="CommandExecutors\TouchPressExecutor.cs" />
     <Compile Include="CommandExecutors\TouchReleaseExecutor.cs" />
     <Compile Include="CommandExecutors\TouchScrollExecutor.cs" />

--- a/src/Winium.Desktop.Driver/Winium.Desktop.Driver.csproj
+++ b/src/Winium.Desktop.Driver/Winium.Desktop.Driver.csproj
@@ -50,6 +50,10 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.ServiceModel" />
+    <Reference Include="TCD.System.TouchInjection, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\TCD.System.TouchInjection.1.0.0\lib\net45\TCD.System.TouchInjection.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="UIAutomationClient" />
     <Reference Include="UIAutomationTypes" />
     <Reference Include="WebDriver, Version=2.46.0.0, Culture=neutral, processorArchitecture=MSIL">

--- a/src/Winium.Desktop.Driver/packages.config
+++ b/src/Winium.Desktop.Driver/packages.config
@@ -6,5 +6,6 @@
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" userInstalled="true" />
   <package id="NLog" version="3.1.0.0" targetFramework="net451" />
   <package id="Selenium.WebDriver" version="2.46.0" targetFramework="net451" userInstalled="true" />
+  <package id="TCD.System.TouchInjection" version="1.0.0" targetFramework="net451" />
   <package id="Winium.Cruciatus" version="2.9.1" targetFramework="net451" />
 </packages>

--- a/src/Winium.StoreApps.Common/DriverCommand.cs
+++ b/src/Winium.StoreApps.Common/DriverCommand.cs
@@ -462,6 +462,18 @@ namespace Winium.StoreApps.Common
         public static readonly string TouchSingleTap = "touchSingleTap";
 
         /// <summary>
+        /// Represents the TouchPerform command.
+        /// 
+        /// </summary>
+        public static readonly string TouchPerform = "touchPerform";
+
+        /// <summary>
+        /// Represents the TouchMultiPerform command.
+        /// 
+        /// </summary>
+        public static readonly string TouchMultiPerform = "touchMultiPerform";
+
+        /// <summary>
         /// Represents the UploadFile command.
         /// 
         /// </summary>


### PR DESCRIPTION
Adds executors for the following touch requests:

- /touch/click
- /touch/doubleclick
- /touch/longclick
- /touch/down
- /touch/up
- /touch/move
- /touch/perform
- /touch/flick
- /touch/scroll

I have not implemented /touch/multi/perform

Also included in this PR are:
- Modification to HTTP request handling so that long requests are not truncated.
- Executor for /element/{id}/location