### PR TITLE
Get and set screen orientation

### DIFF
--- a/src/Winium.Desktop.Driver/CommandExecutors/GetOrientationExecutor.cs
+++ b/src/Winium.Desktop.Driver/CommandExecutors/GetOrientationExecutor.cs
@@ -1,0 +1,23 @@
+namespace Winium.Desktop.Driver.CommandExecutors
+{
+    #region using
+
+    using Winium.Cruciatus.Core;
+    using Winium.StoreApps.Common;
+
+    #endregion
+    
+    internal class GetOrientationExecutor : CommandExecutorBase
+    {
+        #region Methods
+
+        protected override string DoImpl()
+        {
+            var orientation = RotationManager.GetCurrentOrientation();
+
+            return this.JsonResponse(ResponseStatus.Success, orientation.ToString());
+        }
+
+        #endregion
+    }
+}

--- a/src/Winium.Desktop.Driver/CommandExecutors/SetOrientationExecutor.cs
+++ b/src/Winium.Desktop.Driver/CommandExecutors/SetOrientationExecutor.cs
@@ -45,7 +45,7 @@ namespace Winium.Desktop.Driver.CommandExecutors
             }
 
             Logger.Warn(message);
-            return this.JsonResponse(ResponseStatus.UnableToSetDisplayOrientation, message);
+            return this.JsonResponse(ResponseStatus.UnknownError, message);
         }
 
         #endregion

--- a/src/Winium.Desktop.Driver/CommandExecutors/SetOrientationExecutor.cs
+++ b/src/Winium.Desktop.Driver/CommandExecutors/SetOrientationExecutor.cs
@@ -1,0 +1,50 @@
+namespace Winium.Desktop.Driver.CommandExecutors
+{
+    #region using
+
+    using System;
+
+    using Winium.StoreApps.Common;
+    using Winium.Cruciatus.Core;
+
+    #endregion using
+
+    internal class SetOrientationExecutor : CommandExecutorBase
+    {
+        #region Methods
+
+        protected override string DoImpl()
+        {
+            if (!this.ExecutedCommand.Parameters.ContainsKey("orientation"))
+            {
+                // TODO: in the future '400 : invalid argument' will be used
+                return this.JsonResponse(ResponseStatus.UnknownError, "WRONG PARAMETERS");
+            }
+
+            var orientation = (DisplayOrientation)Enum.Parse(
+                typeof(DisplayOrientation), 
+                this.ExecutedCommand.Parameters["orientation"].ToString());
+
+            var result = RotationManager.SetOrientation(orientation);
+
+            switch (result)
+            {
+                case 0:
+                    return this.JsonResponse();
+                case 1:
+                    return this.JsonResponse(
+                        ResponseStatus.UnableToSetDisplayOrientation,
+                        "A device restart is required");
+                case -2:
+                    return this.JsonResponse(
+                        ResponseStatus.UnableToSetDisplayOrientation,
+                        this.ExecutedCommand.Parameters.ContainsKey("orientation") + " not supported by device");
+                default:
+                    return this.JsonResponse(
+                        ResponseStatus.UnableToSetDisplayOrientation, "Unknown error: " + result);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/Winium.Desktop.Driver/CommandExecutors/SetOrientationExecutor.cs
+++ b/src/Winium.Desktop.Driver/CommandExecutors/SetOrientationExecutor.cs
@@ -27,22 +27,25 @@ namespace Winium.Desktop.Driver.CommandExecutors
 
             var result = RotationManager.SetOrientation(orientation);
 
+            string message;
+
             switch (result)
             {
                 case 0:
                     return this.JsonResponse();
                 case 1:
-                    return this.JsonResponse(
-                        ResponseStatus.UnableToSetDisplayOrientation,
-                        "A device restart is required");
+                    message = "A device restart is required";
+                    break;
                 case -2:
-                    return this.JsonResponse(
-                        ResponseStatus.UnableToSetDisplayOrientation,
-                        this.ExecutedCommand.Parameters.ContainsKey("orientation") + " not supported by device");
+                    message = this.ExecutedCommand.Parameters["orientation"] + " not supported by device";
+                    break;
                 default:
-                    return this.JsonResponse(
-                        ResponseStatus.UnableToSetDisplayOrientation, "Unknown error: " + result);
+                    message = "Unknown error: " + result;
+                    break;
             }
+
+            Logger.Warn(message);
+            return this.JsonResponse(ResponseStatus.UnableToSetDisplayOrientation, message);
         }
 
         #endregion

--- a/src/Winium.Desktop.Driver/Winium.Desktop.Driver.csproj
+++ b/src/Winium.Desktop.Driver/Winium.Desktop.Driver.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Automator\Capabilities.cs" />
     <Compile Include="CommandExecutors\CollapseComboBoxExecutor.cs" />
     <Compile Include="CommandExecutors\FindComboBoxSelectedItemExecutor.cs" />
+    <Compile Include="CommandExecutors\GetOrientationExecutor.cs" />
     <Compile Include="CommandExecutors\GetWindowHandlesExecutor.cs" />
     <Compile Include="CommandExecutors\GetCurrentWindowHandleExecutor.cs" />
     <Compile Include="CommandExecutors\GetDataGridRowCountExecutor.cs" />

--- a/src/Winium.Desktop.Driver/Winium.Desktop.Driver.csproj
+++ b/src/Winium.Desktop.Driver/Winium.Desktop.Driver.csproj
@@ -62,7 +62,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Winium.Cruciatus, Version=2.7.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Winium.Cruciatus.2.9.1\lib\net45\Winium.Cruciatus.dll</HintPath>
+      <HintPath>..\packages\Winium.Cruciatus.2.10.0\lib\net45\Winium.Cruciatus.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/src/Winium.Desktop.Driver/Winium.Desktop.Driver.csproj
+++ b/src/Winium.Desktop.Driver/Winium.Desktop.Driver.csproj
@@ -83,6 +83,7 @@
     <Compile Include="CommandExecutors\ScrollToComboBoxItemExecutor.cs" />
     <Compile Include="CommandExecutors\SelectDataGridCellExecutor.cs" />
     <Compile Include="CommandExecutors\FindDataGridCellExecutor.cs" />
+    <Compile Include="CommandExecutors\SetOrientationExecutor.cs" />
     <Compile Include="CommandExecutors\StatusExecutor.cs" />
     <Compile Include="CommandExecutors\SubmitElementExecutor.cs" />
     <Compile Include="CommandExecutors\ExecuteScriptExecutor.cs" />

--- a/src/Winium.Desktop.Driver/packages.config
+++ b/src/Winium.Desktop.Driver/packages.config
@@ -6,5 +6,5 @@
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" userInstalled="true" />
   <package id="NLog" version="3.1.0.0" targetFramework="net451" />
   <package id="Selenium.WebDriver" version="2.46.0" targetFramework="net451" userInstalled="true" />
-  <package id="Winium.Cruciatus" version="2.9.1" targetFramework="net451" />
+  <package id="Winium.Cruciatus" version="2.10.0" targetFramework="net451" />
 </packages>

--- a/src/Winium.StoreApps.Common/ResponseStatus.cs
+++ b/src/Winium.StoreApps.Common/ResponseStatus.cs
@@ -50,8 +50,6 @@
 
         SessionNotCreatedException = 33, 
 
-        MoveTargetOutOfBounds = 34,
-
-        UnableToSetDisplayOrientation = 35
+        MoveTargetOutOfBounds = 34
     }
 }

--- a/src/Winium.StoreApps.Common/ResponseStatus.cs
+++ b/src/Winium.StoreApps.Common/ResponseStatus.cs
@@ -50,6 +50,8 @@
 
         SessionNotCreatedException = 33, 
 
-        MoveTargetOutOfBounds = 34
+        MoveTargetOutOfBounds = 34,
+
+        UnableToSetDisplayOrientation = 35
     }
 }


### PR DESCRIPTION
Adds executors for..

GET /session/{sessionId}/orientation
POST /session/{sessionId}/orientation

Uses RotationManager added to Winium.Cruciatus in https://github.com/2gis/Winium.Cruciatus/pull/55.

As well as PORTRAIT and LANDSCAPE values described within the JSWP spec, PORTRAIT_FLIPPED and LANDSCAPE_FLIPPED are also supported.