### PR TITLE
Handle initial connection closed [FIN,ACK]/[ACK}

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,4 @@ $RECYCLE.BIN/
 
 # Mac crap
 .DS_Store
+src/.nuget/NuGet.exe

--- a/src/Winium.Desktop.Driver/Listener.cs
+++ b/src/Winium.Desktop.Driver/Listener.cs
@@ -87,6 +87,17 @@
                     // Perform a blocking call to accept requests. 
                     var client = this.listener.AcceptTcpClient();
 
+                    //Detect connection close, this happens a lot on Windows 10
+                    if (client.Client.Poll(0, SelectMode.SelectRead))
+                    {
+                        byte[] buff = new byte[1];
+                        if(client.Client.Receive(buff,SocketFlags.Peek) == 0)
+                        {
+                            var ep = (IPEndPoint)client.Client.RemoteEndPoint;
+                            Logger.Debug("Connection disconnected for  IP: {0}/port: {1}",ep.Address, ep.Port);
+                            continue;
+                        }
+                    }
                     // Get a stream object for reading and writing
                     using (var stream = client.GetStream())
                     {


### PR DESCRIPTION
Observed that on Windows 10 + (Python 3.5 64-bit + Selenium 3.0.0.b2), calling webdriver.Remote fails. Upon closer investigation observed that the initial selenium connection is closed (still trying to investigate) and followed by a retry. The issue is that this not handled by Winium.Desktop. The patch handles this situation.