### PR TITLE
Support for selenium 3.3

### DIFF
--- a/src/TestApps.Tests/WindowsFormsTestApplication.Tests/WindowsFormsTestApplication.Tests.csproj
+++ b/src/TestApps.Tests/WindowsFormsTestApplication.Tests/WindowsFormsTestApplication.Tests.csproj
@@ -41,8 +41,8 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.Messaging" />
     <Reference Include="System.Windows.Forms" />
-    <Reference Include="WebDriver, Version=2.53.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Selenium.WebDriver.2.53.1\lib\net40\WebDriver.dll</HintPath>
+    <Reference Include="WebDriver, Version=3.3.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Selenium.WebDriver.3.3.0\lib\net40\WebDriver.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WindowsBase" />

--- a/src/TestApps.Tests/WindowsFormsTestApplication.Tests/packages.config
+++ b/src/TestApps.Tests/WindowsFormsTestApplication.Tests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
-  <package id="Selenium.WebDriver" version="2.53.1" targetFramework="net45" />
+  <package id="Selenium.WebDriver" version="3.3.0" targetFramework="net45" />
 </packages>

--- a/src/TestApps.Tests/WpfTestApplication.Tests/WpfTestApplication.Tests.csproj
+++ b/src/TestApps.Tests/WpfTestApplication.Tests/WpfTestApplication.Tests.csproj
@@ -40,8 +40,8 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
-    <Reference Include="WebDriver, Version=2.53.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Selenium.WebDriver.2.53.1\lib\net40\WebDriver.dll</HintPath>
+    <Reference Include="WebDriver, Version=3.3.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Selenium.WebDriver.3.3.0\lib\net40\WebDriver.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WindowsBase" />

--- a/src/TestApps.Tests/WpfTestApplication.Tests/packages.config
+++ b/src/TestApps.Tests/WpfTestApplication.Tests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
-  <package id="Selenium.WebDriver" version="2.53.1" targetFramework="net45" />
+  <package id="Selenium.WebDriver" version="3.3.0" targetFramework="net45" />
 </packages>

--- a/src/Winium.Desktop.Driver/CommandExecutors/GetSessionCapabilitiesExecutor.cs
+++ b/src/Winium.Desktop.Driver/CommandExecutors/GetSessionCapabilitiesExecutor.cs
@@ -1,0 +1,20 @@
+﻿namespace Winium.Desktop.Driver.CommandExecutors
+{
+    #region using
+
+    using Winium.StoreApps.Common;
+
+    #endregion
+
+    internal class GetSessionCapabilitiesExecutor : CommandExecutorBase
+    {
+        #region Methods
+
+        protected override string DoImpl()
+        {
+            return this.JsonResponse(ResponseStatus.Success, this.Automator.ActualCapabilities);
+        }
+
+        #endregion
+    }
+}

--- a/src/Winium.Desktop.Driver/CommandExecutors/SetTimeoutExecutor.cs
+++ b/src/Winium.Desktop.Driver/CommandExecutors/SetTimeoutExecutor.cs
@@ -1,0 +1,20 @@
+﻿namespace Winium.Desktop.Driver.CommandExecutors
+{
+    #region using
+
+    using Winium.StoreApps.Common;
+
+    #endregion
+
+    internal class SetTimeoutExecutor : CommandExecutorBase
+    {
+        #region Methods
+
+        protected override string DoImpl()
+        {
+            return this.JsonResponse(ResponseStatus.Success, null);
+        }
+
+        #endregion
+    }
+}

--- a/src/Winium.Desktop.Driver/Winium.Desktop.Driver.csproj
+++ b/src/Winium.Desktop.Driver/Winium.Desktop.Driver.csproj
@@ -72,6 +72,7 @@
     <Compile Include="CommandExecutors\CollapseComboBoxExecutor.cs" />
     <Compile Include="CommandExecutors\FindComboBoxSelectedItemExecutor.cs" />
     <Compile Include="CommandExecutors\GetOrientationExecutor.cs" />
+    <Compile Include="CommandExecutors\GetSessionCapabilitiesExecutor.cs" />
     <Compile Include="CommandExecutors\GetWindowHandlesExecutor.cs" />
     <Compile Include="CommandExecutors\GetCurrentWindowHandleExecutor.cs" />
     <Compile Include="CommandExecutors\GetDataGridRowCountExecutor.cs" />
@@ -85,6 +86,7 @@
     <Compile Include="CommandExecutors\SelectDataGridCellExecutor.cs" />
     <Compile Include="CommandExecutors\FindDataGridCellExecutor.cs" />
     <Compile Include="CommandExecutors\SetOrientationExecutor.cs" />
+    <Compile Include="CommandExecutors\SetTimeoutExecutor.cs" />
     <Compile Include="CommandExecutors\StatusExecutor.cs" />
     <Compile Include="CommandExecutors\SubmitElementExecutor.cs" />
     <Compile Include="CommandExecutors\ExecuteScriptExecutor.cs" />

--- a/src/Winium.Desktop.Driver/Winium.Desktop.Driver.csproj
+++ b/src/Winium.Desktop.Driver/Winium.Desktop.Driver.csproj
@@ -52,8 +52,8 @@
     <Reference Include="System.ServiceModel" />
     <Reference Include="UIAutomationClient" />
     <Reference Include="UIAutomationTypes" />
-    <Reference Include="WebDriver, Version=2.53.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Selenium.WebDriver.2.53.1\lib\net40\WebDriver.dll</HintPath>
+    <Reference Include="WebDriver, Version=3.3.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Selenium.WebDriver.3.3.0\lib\net40\WebDriver.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WindowsBase" />

--- a/src/Winium.Desktop.Driver/packages.config
+++ b/src/Winium.Desktop.Driver/packages.config
@@ -5,6 +5,6 @@
   <package id="InputSimulator" version="1.0.4.0" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" userInstalled="true" />
   <package id="NLog" version="3.1.0.0" targetFramework="net451" />
-  <package id="Selenium.WebDriver" version="2.53.1" targetFramework="net451" />
+  <package id="Selenium.WebDriver" version="3.3.0" targetFramework="net451" />
   <package id="Winium.Cruciatus" version="2.10.0" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
We updated to selenium-java 3.3.1 which is used together with Winium.Desktop to run our Windows automation. Unfortunately the recent selenium version (>=3.3) is not compatible with Winium.Desktop anymore, because it lacks some webdriver commands that are now needed. I added implementation for the two commands to make it run again:
* setSessionCapabilities
* setTimeout

The implementation of `setTimeout` is just a stub and return null (which is a valid return value, but will not change the behavior). Maybe that can be changed in a later update.